### PR TITLE
Only use 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "intervention/image": "^2.4",
         "owen-it/laravel-auditing": "8.*",
         "barryvdh/laravel-snappy": "^0.4.3",
-        "myparcelnl/sdk": "^2.1",
+        "myparcelnl/sdk": "~2.1",
         "exdeliver/cart": "dev-master"
     },
     "scripts": {


### PR DESCRIPTION
Because MyParcel will soon have a stable version 3, this will go wrong. You only need to update to version 3 if you are sure that you are ready for version 3. Use a ~ to stay within version 2 (~ is always better than ^).